### PR TITLE
UITableViewDataSource - canEditRowAtIndexPath

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "ReactiveKit"]
-	path = ReactiveKit
-	url = git@github.com:ReactiveKit/ReactiveKit.git
-[submodule "ReactiveFoundation"]
-	path = ReactiveFoundation
-	url = git@github.com:ReactiveKit/ReactiveFoundation.git

--- a/ReactiveUIKit/UITableView.swift
+++ b/ReactiveUIKit/UITableView.swift
@@ -139,7 +139,7 @@ public class RKTableViewDataSource<C: ObservableCollectionType where C.Collectio
   }
   
   @objc public func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-    return proxyDataSource?.tableView?(tableView, canEditRowAtIndexPath: indexPath) ?? false
+    return proxyDataSource?.tableView?(tableView, canEditRowAtIndexPath: indexPath) ?? true
   }
   
   @objc public func tableView(tableView: UITableView, canMoveRowAtIndexPath indexPath: NSIndexPath) -> Bool {


### PR DESCRIPTION
After looking through Apple's [documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITableViewDataSource_Protocol/#//apple_ref/occ/intfm/UITableViewDataSource/tableView:canEditRowAtIndexPath:), I found that `canEditRowAtIndexPath` returns true by default. May I recommend that `canEditRowAtIndexPath` return true unless the `proxyDataSource` returns a value?   
