### PR TITLE
Fix build failure with Carthage

### DIFF
--- a/ReactiveUIKit.xcodeproj/xcshareddata/xcschemes/ReactiveUIKit-iOS.xcscheme
+++ b/ReactiveUIKit.xcodeproj/xcshareddata/xcschemes/ReactiveUIKit-iOS.xcscheme
@@ -3,9 +3,37 @@
    LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ECBCCDCF1BEB6B9A00723476"
+               BuildableName = "ReactiveKit.framework"
+               BlueprintName = "ReactiveKit-iOS"
+               ReferencedContainer = "container:ReactiveKit/ReactiveKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ECBCCE3D1BEB6E2B00723476"
+               BuildableName = "ReactiveFoundation.framework"
+               BlueprintName = "ReactiveFoundation-iOS"
+               ReferencedContainer = "container:ReactiveFoundation/ReactiveFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"

--- a/ReactiveUIKit.xcodeproj/xcshareddata/xcschemes/ReactiveUIKit-tvOS.xcscheme
+++ b/ReactiveUIKit.xcodeproj/xcshareddata/xcschemes/ReactiveUIKit-tvOS.xcscheme
@@ -3,9 +3,37 @@
    LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "16C33AF81BEFB72500A0DBE0"
+               BuildableName = "ReactiveKit.framework"
+               BlueprintName = "ReactiveKit-tvOS"
+               ReferencedContainer = "container:ReactiveKit/ReactiveKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EC95497B1BF1EE70000FC2BF"
+               BuildableName = "ReactiveFoundation.framework"
+               BlueprintName = "ReactiveFoundation-tvOS"
+               ReferencedContainer = "container:ReactiveFoundation/ReactiveFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -29,6 +57,15 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EC9549471BF1EA7A000FC2BF"
+            BuildableName = "ReactiveUIKit.framework"
+            BlueprintName = "ReactiveUIKit-tvOS"
+            ReferencedContainer = "container:ReactiveUIKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>


### PR DESCRIPTION
According to ReactiveKit/ReactiveFoundation#1

Not to use “Parallelize Build” and “Find Implicit Dependencies”.

Fixes ReactiveKit/ReactiveKit#18.
