### PR TITLE
Fix for autocorrect change not sent to UITextField.rText, .rAttributedText

### DIFF
--- a/Sources/UIControl.swift
+++ b/Sources/UIControl.swift
@@ -47,6 +47,7 @@ import ReactiveKit
     control.addTarget(self, action: #selector(RKUIControlHelper.eventHandlerEditingChanged), forControlEvents: UIControlEvents.EditingChanged)
     control.addTarget(self, action: #selector(RKUIControlHelper.eventHandlerEditingDidEnd), forControlEvents: UIControlEvents.EditingDidEnd)
     control.addTarget(self, action: #selector(RKUIControlHelper.eventHandlerEditingDidEndOnExit), forControlEvents: UIControlEvents.EditingDidEndOnExit)
+    control.addTarget(self, action: #selector(RKUIControlHelper.eventHandlerAllEditingEvents), forControlEvents: UIControlEvents.AllEditingEvents)
   }
   
   func eventHandlerTouchDown() {
@@ -104,7 +105,11 @@ import ReactiveKit
   func eventHandlerEditingDidEndOnExit() {
     pushStream.next(.EditingDidEndOnExit)
   }
-  
+
+  func eventHandlerAllEditingEvents() {
+    pushStream.next(.AllEditingEvents)
+  }
+
   deinit {
     control?.removeTarget(self, action: nil, forControlEvents: UIControlEvents.AllEvents)
     pushStream.completed()

--- a/Sources/UITextField.swift
+++ b/Sources/UITextField.swift
@@ -51,9 +51,12 @@ extension UITextField {
         .filter { $0 == UIControlEvents.AllEditingEvents }
         .observeNext { [weak self] event in
           guard let unwrappedSelf = self else { return }
-          updatingFromSelf = true
-          unwrappedSelf.rText.value = unwrappedSelf.text
-          updatingFromSelf = false
+          // only send to rText if value changed, as .AllEditingEvents reports more than just changes
+          if unwrappedSelf.rText.value != unwrappedSelf.text {
+            updatingFromSelf = true
+            unwrappedSelf.rText.value = unwrappedSelf.text
+            updatingFromSelf = false
+          }
         }.disposeIn(rBag)
       
       return rText
@@ -79,9 +82,12 @@ extension UITextField {
         .filter { $0 == UIControlEvents.AllEditingEvents }
         .observeNext { [weak self] event in
           guard let unwrappedSelf = self else { return }
-          updatingFromSelf = true
-          unwrappedSelf.rAttributedText.value = unwrappedSelf.attributedText
-          updatingFromSelf = false
+          // only sent to rAttributedText if value changed, as .AllEditingEvents reports more than just changes
+          if unwrappedSelf.rAttributedText.value != unwrappedSelf.attributedText {
+            updatingFromSelf = true
+            unwrappedSelf.rAttributedText.value = unwrappedSelf.attributedText
+            updatingFromSelf = false
+          }
         }.disposeIn(rBag)
       
       return rAttributedText

--- a/Sources/UITextField.swift
+++ b/Sources/UITextField.swift
@@ -48,7 +48,7 @@ extension UITextField {
       }.disposeIn(rBag)
       
       self.rControlEvent
-        .filter { $0 == UIControlEvents.EditingChanged }
+        .filter { $0 == UIControlEvents.AllEditingEvents }
         .observeNext { [weak self] event in
           guard let unwrappedSelf = self else { return }
           updatingFromSelf = true
@@ -76,7 +76,7 @@ extension UITextField {
       }.disposeIn(rBag)
       
       self.rControlEvent
-        .filter { $0 == UIControlEvents.EditingChanged }
+        .filter { $0 == UIControlEvents.AllEditingEvents }
         .observeNext { [weak self] event in
           guard let unwrappedSelf = self else { return }
           updatingFromSelf = true


### PR DESCRIPTION
UITextField does not send UIControlEvents.EditingChanged when accepting an autocorrect change.
To work around this, I've observed UIControlEvents.AllEditingEvents and only sending value to rText/rAttributedText when the value has changed.
Other reactive frameworks have had this issue too, see https://github.com/ReactiveX/RxSwift/pull/360/commits/8a15b9223612ae7a0881f3413ca7a5576779ce25
